### PR TITLE
Warn on upstream conflicts

### DIFF
--- a/Casks/consul@1.0.0-beta1.rb
+++ b/Casks/consul@1.0.0-beta1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.0-beta1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.0-beta2.rb
+++ b/Casks/consul@1.0.0-beta2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.0-beta2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.0.rb
+++ b/Casks/consul@1.0.0.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.0' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.1-rc1.rb
+++ b/Casks/consul@1.0.1-rc1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.1-rc1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.1.rb
+++ b/Casks/consul@1.0.1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.2.rb
+++ b/Casks/consul@1.0.2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.3.rb
+++ b/Casks/consul@1.0.3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.5.rb
+++ b/Casks/consul@1.0.5.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.5' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.6.rb
+++ b/Casks/consul@1.0.6.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.6' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.7.rb
+++ b/Casks/consul@1.0.7.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.7' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.0.8.rb
+++ b/Casks/consul@1.0.8.rb
@@ -9,6 +9,7 @@ cask 'consul@1.0.8' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.1.0.rb
+++ b/Casks/consul@1.1.0.rb
@@ -9,6 +9,7 @@ cask 'consul@1.1.0' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.1.1.rb
+++ b/Casks/consul@1.1.1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.1.1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.0+ent.rb
+++ b/Casks/consul@1.2.0+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.0+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.0.rb
+++ b/Casks/consul@1.2.0.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.0' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.1+ent.rb
+++ b/Casks/consul@1.2.1+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.1+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.1.rb
+++ b/Casks/consul@1.2.1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.2+ent.rb
+++ b/Casks/consul@1.2.2+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.2+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.2.rb
+++ b/Casks/consul@1.2.2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.3+ent.rb
+++ b/Casks/consul@1.2.3+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.3+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.3.rb
+++ b/Casks/consul@1.2.3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.4+ent.rb
+++ b/Casks/consul@1.2.4+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.4+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.2.4.rb
+++ b/Casks/consul@1.2.4.rb
@@ -9,6 +9,7 @@ cask 'consul@1.2.4' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.3.0+ent.rb
+++ b/Casks/consul@1.3.0+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.3.0+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.3.0.rb
+++ b/Casks/consul@1.3.0.rb
@@ -9,6 +9,7 @@ cask 'consul@1.3.0' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.3.1+ent.rb
+++ b/Casks/consul@1.3.1+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.3.1+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.3.1.rb
+++ b/Casks/consul@1.3.1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.3.1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.0+ent.rb
+++ b/Casks/consul@1.4.0+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.0+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.0-rc1.rb
+++ b/Casks/consul@1.4.0-rc1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.0-rc1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.0.rb
+++ b/Casks/consul@1.4.0.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.0' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.1+ent.rb
+++ b/Casks/consul@1.4.1+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.1+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.1.rb
+++ b/Casks/consul@1.4.1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.2+ent.rb
+++ b/Casks/consul@1.4.2+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.2+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.2.rb
+++ b/Casks/consul@1.4.2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.3+ent.rb
+++ b/Casks/consul@1.4.3+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.3+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.3.rb
+++ b/Casks/consul@1.4.3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.4+ent.rb
+++ b/Casks/consul@1.4.4+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.4+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.4.rb
+++ b/Casks/consul@1.4.4.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.4' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.5+ent.rb
+++ b/Casks/consul@1.4.5+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.5+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.4.5.rb
+++ b/Casks/consul@1.4.5.rb
@@ -9,6 +9,7 @@ cask 'consul@1.4.5' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.5.0+ent.rb
+++ b/Casks/consul@1.5.0+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.5.0+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.5.0.rb
+++ b/Casks/consul@1.5.0.rb
@@ -9,6 +9,7 @@ cask 'consul@1.5.0' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.5.1+ent.rb
+++ b/Casks/consul@1.5.1+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.5.1+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.5.1.rb
+++ b/Casks/consul@1.5.1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.5.1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.5.2+ent.rb
+++ b/Casks/consul@1.5.2+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.5.2+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.5.2.rb
+++ b/Casks/consul@1.5.2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.5.2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.5.3+ent.rb
+++ b/Casks/consul@1.5.3+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.5.3+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.5.3.rb
+++ b/Casks/consul@1.5.3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.5.3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0+ent-beta1.rb
+++ b/Casks/consul@1.6.0+ent-beta1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0+ent-beta1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0+ent-beta2.rb
+++ b/Casks/consul@1.6.0+ent-beta2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0+ent-beta2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0+ent-beta3.rb
+++ b/Casks/consul@1.6.0+ent-beta3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0+ent-beta3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0+ent-rc1.rb
+++ b/Casks/consul@1.6.0+ent-rc1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0+ent-rc1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0+ent.rb
+++ b/Casks/consul@1.6.0+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0-beta1.rb
+++ b/Casks/consul@1.6.0-beta1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0-beta1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0-beta2.rb
+++ b/Casks/consul@1.6.0-beta2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0-beta2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0-beta3.rb
+++ b/Casks/consul@1.6.0-beta3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0-beta3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0-rc1.rb
+++ b/Casks/consul@1.6.0-rc1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0-rc1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.0.rb
+++ b/Casks/consul@1.6.0.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.0' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.1+ent.rb
+++ b/Casks/consul@1.6.1+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.1+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.1.rb
+++ b/Casks/consul@1.6.1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.2+ent.rb
+++ b/Casks/consul@1.6.2+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.2+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.2.rb
+++ b/Casks/consul@1.6.2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.3+ent.rb
+++ b/Casks/consul@1.6.3+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.3+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.3.rb
+++ b/Casks/consul@1.6.3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.4+ent.rb
+++ b/Casks/consul@1.6.4+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.4+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.6.4.rb
+++ b/Casks/consul@1.6.4.rb
@@ -9,6 +9,7 @@ cask 'consul@1.6.4' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0+ent-beta1.rb
+++ b/Casks/consul@1.7.0+ent-beta1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0+ent-beta1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0+ent-beta2.rb
+++ b/Casks/consul@1.7.0+ent-beta2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0+ent-beta2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0+ent-beta3.rb
+++ b/Casks/consul@1.7.0+ent-beta3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0+ent-beta3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0+ent-beta4.rb
+++ b/Casks/consul@1.7.0+ent-beta4.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0+ent-beta4' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0+ent.rb
+++ b/Casks/consul@1.7.0+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0-beta1.rb
+++ b/Casks/consul@1.7.0-beta1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0-beta1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0-beta2.rb
+++ b/Casks/consul@1.7.0-beta2.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0-beta2' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0-beta3.rb
+++ b/Casks/consul@1.7.0-beta3.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0-beta3' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0-beta4.rb
+++ b/Casks/consul@1.7.0-beta4.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0-beta4' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.0.rb
+++ b/Casks/consul@1.7.0.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.0' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.1+ent.rb
+++ b/Casks/consul@1.7.1+ent.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.1+ent' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.1.rb
+++ b/Casks/consul@1.7.1.rb
@@ -9,6 +9,7 @@ cask 'consul@1.7.1' do
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/Casks/consul@1.7.2+ent.rb
+++ b/Casks/consul@1.7.2+ent.rb
@@ -1,0 +1,15 @@
+cask 'consul@1.7.2+ent' do
+  version '1.7.2+ent'
+  sha256 '18fab5ce3d50373d638a904024c62ab1af5432cf64956de1445bdc26c4dda0df'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/consul/1.7.2+ent/consul_1.7.2+ent_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/consul/releases.atom'
+  name 'Consul'
+  homepage 'https://www.consul.io/'
+
+  auto_updates false
+  conflicts_with formula: 'consul'
+
+  binary 'consul'
+end

--- a/Casks/consul@1.7.2.rb
+++ b/Casks/consul@1.7.2.rb
@@ -1,0 +1,15 @@
+cask 'consul@1.7.2' do
+  version '1.7.2'
+  sha256 'c474f00b022cae38acae2d19b2a707a4fcb08dfdd22875efeefdf052ce19c90b'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/consul/1.7.2/consul_1.7.2_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/consul/releases.atom'
+  name 'Consul'
+  homepage 'https://www.consul.io/'
+
+  auto_updates false
+  conflicts_with formula: 'consul'
+
+  binary 'consul'
+end

--- a/Casks/nomad@0.10.0-beta1.rb
+++ b/Casks/nomad@0.10.0-beta1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.0-beta1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.10.0-rc1.rb
+++ b/Casks/nomad@0.10.0-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.0-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.10.0.rb
+++ b/Casks/nomad@0.10.0.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.0' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.10.1.rb
+++ b/Casks/nomad@0.10.1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.10.2-rc1.rb
+++ b/Casks/nomad@0.10.2-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.2-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.10.2.rb
+++ b/Casks/nomad@0.10.2.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.2' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.10.3.rb
+++ b/Casks/nomad@0.10.3.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.3' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.10.4-rc1.rb
+++ b/Casks/nomad@0.10.4-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.4-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.10.4.rb
+++ b/Casks/nomad@0.10.4.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.10.4' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.0-rc1.rb
+++ b/Casks/nomad@0.8.0-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.0-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.0.rb
+++ b/Casks/nomad@0.8.0.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.0' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.1.rb
+++ b/Casks/nomad@0.8.1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.2.rb
+++ b/Casks/nomad@0.8.2.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.2' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.3.rb
+++ b/Casks/nomad@0.8.3.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.3' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.4-rc1.rb
+++ b/Casks/nomad@0.8.4-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.4-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.4.rb
+++ b/Casks/nomad@0.8.4.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.4' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.5.rb
+++ b/Casks/nomad@0.8.5.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.5' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.6.rb
+++ b/Casks/nomad@0.8.6.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.6' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.7-rc1.rb
+++ b/Casks/nomad@0.8.7-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.7-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.8.7.rb
+++ b/Casks/nomad@0.8.7.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.8.7' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.0-beta1.rb
+++ b/Casks/nomad@0.9.0-beta1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.0-beta1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.0-beta2.rb
+++ b/Casks/nomad@0.9.0-beta2.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.0-beta2' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.0-beta3.rb
+++ b/Casks/nomad@0.9.0-beta3.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.0-beta3' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.0-rc1.rb
+++ b/Casks/nomad@0.9.0-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.0-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.0-rc2.rb
+++ b/Casks/nomad@0.9.0-rc2.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.0-rc2' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.0.rb
+++ b/Casks/nomad@0.9.0.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.0' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.1-rc1.rb
+++ b/Casks/nomad@0.9.1-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.1-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.1.rb
+++ b/Casks/nomad@0.9.1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.2-rc1.rb
+++ b/Casks/nomad@0.9.2-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.2-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.2.rb
+++ b/Casks/nomad@0.9.2.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.2' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.3.rb
+++ b/Casks/nomad@0.9.3.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.3' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.4-rc1.rb
+++ b/Casks/nomad@0.9.4-rc1.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.4-rc1' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.4.rb
+++ b/Casks/nomad@0.9.4.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.4' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.5.rb
+++ b/Casks/nomad@0.9.5.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.5' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.6.rb
+++ b/Casks/nomad@0.9.6.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.6' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/nomad@0.9.7.rb
+++ b/Casks/nomad@0.9.7.rb
@@ -9,6 +9,7 @@ cask 'nomad@0.9.7' do
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/Casks/vagrant@1.8.0.rb
+++ b/Casks/vagrant@1.8.0.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.8.0' do
   version '1.8.0'
   sha256 'cfc63e433c9aef61384175b263dea081f8b570b6a3e69edd0b77c47c96dce84d'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.8.0/vagrant_1.8.0.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.8.1.rb
+++ b/Casks/vagrant@1.8.1.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.8.1' do
   version '1.8.1'
   sha256 '2cfdbeec9e40376e49dae9d9f27511896e3b296f0e24f8731339bb3d32c48c93'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.8.3.rb
+++ b/Casks/vagrant@1.8.3.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.8.3' do
   version '1.8.3'
   sha256 'c510dcbc02ef7896674c25b62ae3c3342141575a93ae635a8da95b98c0268a06'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.8.3/vagrant_1.8.3.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.8.4.rb
+++ b/Casks/vagrant@1.8.4.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.8.4' do
   version '1.8.4'
   sha256 'c124089c1b800e480d5777c5ef344c2731853dd237d7c70220245fafa3051fbd'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.8.4/vagrant_1.8.4.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.8.5.rb
+++ b/Casks/vagrant@1.8.5.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.8.5' do
   version '1.8.5'
   sha256 'f12879c4890c39ec49af95153a6151b19fd137cbdccf7db22470f31464b9dd56'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.8.5/vagrant_1.8.5.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.8.6.rb
+++ b/Casks/vagrant@1.8.6.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.8.6' do
   version '1.8.6'
   sha256 'b916cd103c91faf57b63b49188e4cd09136f81385ff05d62e55b68c87b53a2d9'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.8.6/vagrant_1.8.6.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.8.7.rb
+++ b/Casks/vagrant@1.8.7.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.8.7' do
   version '1.8.7'
   sha256 '14d68f599a620cf421838ed037f0a1c4467e1b67475deeff62330a21fda4937b'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.8.7/vagrant_1.8.7.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.0.rb
+++ b/Casks/vagrant@1.9.0.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.0' do
   version '1.9.0'
   sha256 '896eb09fdd4b35ecb4d7cb02394b0a7b57cda1cb218a4b0d6e0d9340265f8590'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.0/vagrant_1.9.0.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.1.rb
+++ b/Casks/vagrant@1.9.1.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.1' do
   version '1.9.1'
   sha256 '17191ff7a1d796aa89c558b45c706288275dade6a65e2b219c2efa0e54c02ef7'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.1/vagrant_1.9.1.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.2.rb
+++ b/Casks/vagrant@1.9.2.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.2' do
   version '1.9.2'
   sha256 'ee0549a16859042d39c08ae153895da6cdfbad7c587b3438349cdf01efe10703'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.2/vagrant_1.9.2.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.3.rb
+++ b/Casks/vagrant@1.9.3.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.3' do
   version '1.9.3'
   sha256 '7e08c3d204420027142d6623d2b02c5ec00f635a74b4ca7fb742e91894b942b8'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.3/vagrant_1.9.3_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.4.rb
+++ b/Casks/vagrant@1.9.4.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.4' do
   version '1.9.4'
   sha256 '2ae186e762498c8e018efbf3452a3d368627cb7d518b26f3f445f0a3686e5a07'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.4/vagrant_1.9.4_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.5.rb
+++ b/Casks/vagrant@1.9.5.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.5' do
   version '1.9.5'
   sha256 'ac16217b114d8816264700e41114b62acd0c071d2699ae13954086ae3fcb151c'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.5/vagrant_1.9.5_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.6.rb
+++ b/Casks/vagrant@1.9.6.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.6' do
   version '1.9.6'
   sha256 'bf3ed196cc12f9906d1d1dbe38c297d42e1de318f1ac0f7eb720894af9519141'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.6/vagrant_1.9.6_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.7.rb
+++ b/Casks/vagrant@1.9.7.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.7' do
   version '1.9.7'
   sha256 '3ebb9bf1f7d7bb947da52c33cb540750156f4a9ba1c1697c07bb9317d42ea503'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.7/vagrant_1.9.7_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@1.9.8.rb
+++ b/Casks/vagrant@1.9.8.rb
@@ -2,11 +2,13 @@ cask 'vagrant@1.9.8' do
   version '1.9.8'
   sha256 '11b1bfac9e58d6189cd08d77e2943c89e0a6629f5a84abe1629f270813d5e818'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/1.9.8/vagrant_1.9.8_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@2.0.0.rb
+++ b/Casks/vagrant@2.0.0.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.0.0' do
   version '2.0.0'
   sha256 '596fba741f99a083eed9751973b4a3016c99de611165ca561922008d23008494'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.0.0/vagrant_2.0.0_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg', allow_untrusted: true
 

--- a/Casks/vagrant@2.0.1.rb
+++ b/Casks/vagrant@2.0.1.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.0.1' do
   version '2.0.1'
   sha256 '07f7be3a457a8422d576e6371c8499fbdea411b02aecc7ea3c5258494514c5f2'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.0.1/vagrant_2.0.1_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.0.2.rb
+++ b/Casks/vagrant@2.0.2.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.0.2' do
   version '2.0.2'
   sha256 'c5dd5b8c7193844a6cc5b6f79b0c878cd144f1eebbac72ad70de0f3cfdb31d93'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.0.2/vagrant_2.0.2_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.0.3.rb
+++ b/Casks/vagrant@2.0.3.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.0.3' do
   version '2.0.3'
   sha256 '4ccdd7530a4b0172339c84a61a22bf7868c9fd1d173e7b510cf21f6deb26776e'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.0.3/vagrant_2.0.3_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.0.4.rb
+++ b/Casks/vagrant@2.0.4.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.0.4' do
   version '2.0.4'
   sha256 '105fb631d5ae29f9f01d9680f52ba31e63727fefd77f360df9e91a528c354d01'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.0.4/vagrant_2.0.4_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.1.0.rb
+++ b/Casks/vagrant@2.1.0.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.1.0' do
   version '2.1.0'
   sha256 'fbbec9a335ab69b1a2b5535bca59b49034bb38c592c05f0f70fc120e25f71a4d'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.1.0/vagrant_2.1.0_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.1.1.rb
+++ b/Casks/vagrant@2.1.1.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.1.1' do
   version '2.1.1'
   sha256 '9d1798396f05b8c39f65f1e7878f088302546a5baa59846fbf461589d76e3e1f'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.1.1/vagrant_2.1.1_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.1.2.rb
+++ b/Casks/vagrant@2.1.2.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.1.2' do
   version '2.1.2'
   sha256 'dd9cacd2d1fcf03e22343de9698f89c1547ab74cfb4a64b7deb8ed1b3e12bb16'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.1.2/vagrant_2.1.2_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.1.3.rb
+++ b/Casks/vagrant@2.1.3.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.1.3' do
   version '2.1.3'
   sha256 '0b7deb138092b016dd64061292ce6585bad670e4fc85162651dc93919a2e6b63'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.1.3/vagrant_2.1.3_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.1.4.rb
+++ b/Casks/vagrant@2.1.4.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.1.4' do
   version '2.1.4'
   sha256 'aa097c786bbda33bfe39999a8c353715afe591b593d9a9e5ae422160d3689ae9'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.1.4/vagrant_2.1.4_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.1.5.rb
+++ b/Casks/vagrant@2.1.5.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.1.5' do
   version '2.1.5'
   sha256 '8799fb5c8336d735c44f7481bf41135768d395cb5b79e0e4ef5145465ee4778a'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.1.5/vagrant_2.1.5_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.2.0.rb
+++ b/Casks/vagrant@2.2.0.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.2.0' do
   version '2.2.0'
   sha256 '016bf5470cf940df50dceae7fd5f0d333617ca42835f106846c91669b3305255'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.2.0/vagrant_2.2.0_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.2.1.rb
+++ b/Casks/vagrant@2.2.1.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.2.1' do
   version '2.2.1'
   sha256 '84794e12d0037fbd580ff3bc61418c0027dc01ec777a638cae2351c97a758d41'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.2.1/vagrant_2.2.1_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.2.2.rb
+++ b/Casks/vagrant@2.2.2.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.2.2' do
   version '2.2.2'
   sha256 'c3b637e3d648c755b9b30197e820ca64a7062e40b3240bc08c4bfdd98925978b'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.2.2/vagrant_2.2.2_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.2.3.rb
+++ b/Casks/vagrant@2.2.3.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.2.3' do
   version '2.2.3'
   sha256 'd6f68ed8d69d6465e13ab668542bacc9a1752cf60f47464fa46604c147c81be4'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.2.3/vagrant_2.2.3_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.2.4.rb
+++ b/Casks/vagrant@2.2.4.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.2.4' do
   version '2.2.4'
   sha256 'a09a2f0fb3fcbd4cfb41c7812c01605173f64056449c3dbcc513b4211e9c1e8d'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.2.4/vagrant_2.2.4_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.2.5.rb
+++ b/Casks/vagrant@2.2.5.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.2.5' do
   version '2.2.5'
   sha256 '147b795b9df57ae9d88b97a41eb4328d2dc72a86f82b6d8f1d3d9958109b3a23'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.2.5/vagrant_2.2.5_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.2.6.rb
+++ b/Casks/vagrant@2.2.6.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.2.6' do
   version '2.2.6'
   sha256 'd5398ec0a29938017c27e98c5a4445ed64f131caa115265da61c795229ef47f7'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.2.6/vagrant_2.2.6_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/Casks/vagrant@2.2.7.rb
+++ b/Casks/vagrant@2.2.7.rb
@@ -2,11 +2,13 @@ cask 'vagrant@2.2.7' do
   version '2.2.7'
   sha256 '45472731bde1df0bf2e0e0cf1ee460e2851c920d8b7b8af939e41156515cf49c'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
+  # releases.hashicorp.com was verified as official when first introduced to the cask
   url 'https://releases.hashicorp.com/vagrant/2.2.7/vagrant_2.2.7_x86_64.dmg'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
+
+  conflicts_with cask: 'vagrant'
 
   pkg 'vagrant.pkg'
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ brew tap operatehappy/homebrew-hashicorp
 Once the tap is installed, you will have access to the following applications and versions
 
 - Casks
-  - Consul `>= 1.0.0` and `<= 1.7.1`
+  - Consul `>= 1.0.0` and `<= 1.7.2`
+  - Nomad `>= 0.8.0-rc1` and `<= 0.10.4`
   - Vagrant `>= 1.8.0` and `<= 2.2.7`
+  - Vault `>= 0.7.0` and `<= 1.4.0-beta1`
 
 ### Installing a Cask
 

--- a/helpers/VERSIONS.sh
+++ b/helpers/VERSIONS.sh
@@ -55,7 +55,7 @@ CONSUL_15X=("1.5.0+ent" "1.5.0" "1.5.1" "1.5.1+ent" "1.5.2+ent" "1.5.2" "1.5.3" 
 CONSUL_16X=("1.6.0-beta1" "1.6.0-beta2" "1.6.0-beta3" "1.6.0-rc1" "1.6.0" "1.6.0+ent-rc1" "1.6.0+ent-beta3" "1.6.0+ent-beta1" "1.6.0+ent" "1.6.0+ent-beta2" "1.6.1+ent" "1.6.1" "1.6.2" "1.6.2+ent" "1.6.3+ent" "1.6.3" "1.6.4+ent" "1.6.4")
 
 # released between 2020-02 and 2020-02
-CONSUL_17X=("1.7.0-beta1" "1.7.0-beta2" "1.7.0-beta3" "1.7.0-beta4" "1.7.0" "1.7.0+ent-beta2" "1.7.0+ent-beta1" "1.7.0+ent-beta3" "1.7.0+ent" "1.7.0+ent-beta4" "1.7.1+ent" "1.7.1")
+CONSUL_17X=("1.7.0-beta1" "1.7.0-beta2" "1.7.0-beta3" "1.7.0-beta4" "1.7.0" "1.7.0+ent-beta2" "1.7.0+ent-beta1" "1.7.0+ent-beta3" "1.7.0+ent" "1.7.0+ent-beta4" "1.7.1+ent" "1.7.1" "1.7.2" "1.7.2+ent")
 
 CONSUL_1XX=("${CONSUL_10X[@]}" "${CONSUL_11X[@]}" "${CONSUL_12X[@]}" "${CONSUL_13X[@]}" "${CONSUL_14X[@]}" "${CONSUL_15X[@]}" "${CONSUL_16X[@]}" "${CONSUL_17X[@]}")
 

--- a/helpers/templates/consul.cask
+++ b/helpers/templates/consul.cask
@@ -1,14 +1,15 @@
-cask 'consul@%%VERSION%%' do
-  version '%%VERSION%%'
-  sha256 '%%CHECKSUM%%'
+cask 'consul@%%PRODUCT_VERSION%%' do
+  version '%%PRODUCT_VERSION%%'
+  sha256 '%%PRODUCT_CHECKSUM%%'
 
   # releases.hashicorp.com was verified as official when first introduced to the cask
-  url 'https://releases.hashicorp.com/consul/%%VERSION%%/consul_%%VERSION%%%%ARCHITECTURE%%.zip'
+  url 'https://releases.hashicorp.com/consul/%%PRODUCT_VERSION%%/consul_%%PRODUCT_VERSION%%%%PRODUCT_ARCHITECTURE%%.%%PRODUCT_FILE_EXTENSION%%'
   appcast 'https://github.com/hashicorp/consul/releases.atom'
   name 'Consul'
   homepage 'https://www.consul.io/'
 
   auto_updates false
+  conflicts_with formula: 'consul'
 
   binary 'consul'
 end

--- a/helpers/templates/nomad.cask
+++ b/helpers/templates/nomad.cask
@@ -1,14 +1,15 @@
-cask 'nomad@%%VERSION%%' do
-  version '%%VERSION%%'
-  sha256 '%%CHECKSUM%%'
+cask 'nomad@%%PRODUCT_VERSION%%' do
+  version '%%PRODUCT_VERSION%%'
+  sha256 '%%PRODUCT_CHECKSUM%%'
 
   # releases.hashicorp.com was verified as official when first introduced to the cask
-  url 'https://releases.hashicorp.com/nomad/%%VERSION%%/nomad_%%VERSION%%%%ARCHITECTURE%%.zip'
+  url 'https://releases.hashicorp.com/nomad/%%PRODUCT_VERSION%%/nomad_%%PRODUCT_VERSION%%%%PRODUCT_ARCHITECTURE%%.%%PRODUCT_FILE_EXTENSION%%'
   appcast 'https://github.com/hashicorp/nomad/releases.atom'
   name 'Nomad'
   homepage 'https://www.nomadproject.io/'
 
   auto_updates false
+  conflicts_with formula: 'nomad'
 
   binary 'nomad'
 end

--- a/helpers/templates/vagrant.cask
+++ b/helpers/templates/vagrant.cask
@@ -1,14 +1,16 @@
-cask 'vagrant@%%VERSION%%' do
-  version '%%VERSION%%'
-  sha256 '%%CHECKSUM%%'
+cask 'vagrant@%%PRODUCT_VERSION%%' do
+  version '%%PRODUCT_VERSION%%'
+  sha256 '%%PRODUCT_CHECKSUM%%'
 
-  # releases.hashicorp.com/vagrant was verified as official when first introduced to the cask
-  url 'https://releases.hashicorp.com/vagrant/%%VERSION%%/vagrant_%%VERSION%%%%ARCHITECTURE%%.dmg'
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/vagrant/%%PRODUCT_VERSION%%/vagrant_%%PRODUCT_VERSION%%%%PRODUCT_ARCHITECTURE%%.%%PRODUCT_FILE_EXTENSION%%'
   appcast 'https://github.com/hashicorp/vagrant/releases.atom'
   name 'Vagrant'
   homepage 'https://www.vagrantup.com/'
 
-  pkg 'vagrant.pkg'%%PACKAGE_FLAG%%
+  conflicts_with cask: 'vagrant'
+
+  pkg 'vagrant.pkg'%%PRODUCT_FLAGS%%
 
   uninstall script:  {
                        executable: 'uninstall.tool',


### PR DESCRIPTION
This adds the [conflicts_with](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/conflicts_with.md) stanza to _all_ casks, making this a rather large PR.

`conflicts_with` should bubble up any issues if users have upstream formulae or casks installed, already.

Additionally, this also adds Consul `1.7.2` (incl. `+ent`)

# Added Cask(s)

- `consul@1.7.2`
- `consul@1.7.2+ent`

# TODO

- [X] Checked open [Pull Requests](https://github.com/operatehappy/homebrew-hashicorp/pulls) for the same Cask update
- [X] Built the Cask locally and verified its installability
- [X] Audited the Cask using `brew cask audit product@x.y.z` or `brew cask audit product@x.y.z` respectively
