### PR TITLE
Adds Vault Casks for 1.3.4 and 1.4.0-rc1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,9 @@ Any other relevant environment information:
 
 # TODO
 
-- [ ] Checked open [Pull Requests](https://github.com/operatehappy/homebrew-hashicorp/pulls) for the same Cask update
+- [ ] Checked open [Pull Requests](https://github.com/operatehappy/homebrew-hashicorp/pulls) for a similar Cask update
 - [ ] Built the Cask locally and verified its installability
-- [ ] Audited the Cask using `brew cask audit product@x.y.z` or `brew cask audit product@x.y.z` respectively
+- [ ] Tested installability using `brew cask install product@x.y.z.rb`
+- [ ] Tested uninstallability using `brew cask uninstall product@x.y.z.rb`
+- [ ] Audited the Cask using `brew cask audit --download product@x.y.z` with no errors
+- [ ] Style-checked the Cask using `brew cask style --fix product@x.y.z` and reported no offenses

--- a/Casks/vault@1.3.4+ent.rb
+++ b/Casks/vault@1.3.4+ent.rb
@@ -1,0 +1,15 @@
+cask 'vault@1.3.4+ent' do
+  version '1.3.4+ent'
+  sha256 '66244de0cf1dc8c533db0cc87119c20fedfe3885b2c0122b3e8d755c7c4b27c1'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/vault/1.3.4+ent/vault_1.3.4+ent_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/vault/releases.atom'
+  name 'Vault'
+  homepage 'https://www.vaultproject.io/'
+
+  auto_updates false
+  conflicts_with formula: 'vault'
+
+  binary 'vault'
+end

--- a/Casks/vault@1.3.4.rb
+++ b/Casks/vault@1.3.4.rb
@@ -1,0 +1,15 @@
+cask 'vault@1.3.4' do
+  version '1.3.4'
+  sha256 '76299a3502f22920076cd991771dc4422c17f80b834143eca5b28460e744155f'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/vault/1.3.4/vault_1.3.4_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/vault/releases.atom'
+  name 'Vault'
+  homepage 'https://www.vaultproject.io/'
+
+  auto_updates false
+  conflicts_with formula: 'vault'
+
+  binary 'vault'
+end

--- a/Casks/vault@1.4.0-rc1+ent.rb
+++ b/Casks/vault@1.4.0-rc1+ent.rb
@@ -1,0 +1,15 @@
+cask 'vault@1.4.0-rc1+ent' do
+  version '1.4.0-rc1+ent'
+  sha256 '082c36754d86e01fd4a33c460095ed5066dea63b2acfcdc7a8cee87e74a73ddb'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/vault/1.4.0-rc1+ent/vault_1.4.0-rc1+ent_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/vault/releases.atom'
+  name 'Vault'
+  homepage 'https://www.vaultproject.io/'
+
+  auto_updates false
+  conflicts_with formula: 'vault'
+
+  binary 'vault'
+end

--- a/Casks/vault@1.4.0-rc1.rb
+++ b/Casks/vault@1.4.0-rc1.rb
@@ -1,0 +1,15 @@
+cask 'vault@1.4.0-rc1' do
+  version '1.4.0-rc1'
+  sha256 '9635b72acfe1968e2e6a420b4e8f2081ff65a59226202775eff81057b36f15ad'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/vault/1.4.0-rc1/vault_1.4.0-rc1_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/vault/releases.atom'
+  name 'Vault'
+  homepage 'https://www.vaultproject.io/'
+
+  auto_updates false
+  conflicts_with formula: 'vault'
+
+  binary 'vault'
+end

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This Tap provides an exhaustive range of versions for the following applications
   - Packer `>= 1.0.0` and `<= 1.5.4`
   - Nomad `>= 0.8.0-rc1` and `<= 0.10.4`
   - Vagrant `>= 1.8.0` and `<= 2.2.7`
-  - Vault `>= 0.7.0` and `<= 1.4.0-beta1`
+  - Vault `>= 0.7.0` and `<= 1.4.0-rc1`
 - misc. Casks
   - `consul-aws` `>= 0.1.0` and `<= 0.1.1`
   - `consul-template` `>= 0.1.0` and `<= 0.9.2`

--- a/helpers/VERSIONS.sh
+++ b/helpers/VERSIONS.sh
@@ -326,12 +326,12 @@ VAULT_12X_PREFIXED=("1.2.3+ent")
 VAULT_12X=("${VAULT_12X_NONPREFIXED[@]}" "${VAULT_12X_PREFIXED[@]}")
 
 # released between 2019-11 and 2020-03
-# versions `1.3.0-beta1+ent.hsm`, `1.3.0+ent.hsm`, `1.3.1+ent.hsm`, `1.3.2+ent.hsm`, and `1.3.3+ent.hsm` were not released for macOS and are therefore omitted
-VAULT_13X=("1.3.0" "1.3.0-beta1" "1.3.0-beta1+ent" "1.3.0+ent" "1.3.1" "1.3.1+ent" "1.3.2" "1.3.2+ent" "1.3.3" "1.3.3+ent")
+# versions `1.3.0-beta1+ent.hsm`, `1.3.0+ent.hsm`, `1.3.1+ent.hsm`, `1.3.2+ent.hsm`, `1.3.3+ent.hsm`, and `1.3.4+ent.hsm` were not released for macOS and are therefore omitted
+VAULT_13X=("1.3.0" "1.3.0-beta1" "1.3.0-beta1+ent" "1.3.0+ent" "1.3.1" "1.3.1+ent" "1.3.2" "1.3.2+ent" "1.3.3" "1.3.3+ent" "1.3.4" "1.3.4+ent")
 
 # released in 2020-02
-# versions `1.4.0-beta1+ent.hsm` were not released for macOS and are therefore omitted
-VAULT_14X=("1.4.0-beta1" "1.4.0-beta1+ent")
+# versions `1.4.0-beta1+ent.hsm` and `1.4.0-rc1+ent.hsm` were not released for macOS and are therefore omitted
+VAULT_14X=("1.4.0-beta1" "1.4.0-beta1+ent" "1.4.0-rc1" "1.4.0-rc1+ent")
 
 VAULT_0XX=("${VAULT_07X[@]}" "${VAULT_08X[@]}" "${VAULT_09X[@]}" "${VAULT_010X[@]}" "${VAULT_011X[@]}")
 VAULT_1XX=("${VAULT_10X[@]}" "${VAULT_11X[@]}" "${VAULT_12X[@]}" "${VAULT_13X[@]}" "${VAULT_14X[@]}")


### PR DESCRIPTION
<!-- Please provide a general summary of the pull request in the Title above -->

# Added Cask(s)

- `vault@1.3.4`
- `vault@1.3.4+ent`
- `vault@1.4.0-rc1`
- `vault@1.4.0-rc1+ent`

<!-- Explain what you expect to happen -->

Any other relevant environment information:

```sh

```

# TODO

- [X] Checked open [Pull Requests](https://github.com/operatehappy/homebrew-hashicorp/pulls) for the same Cask update
- [X] Built the Cask locally and verified its installability
- [X] Audited the Cask using `brew cask audit product@x.y.z` or `brew cask audit product@x.y.z` respectively
