### PR TITLE
Updates Casks for `consul-aws`, `nomad` and `vault` 

### DIFF
--- a/Casks/consul-aws@0.1.2.rb
+++ b/Casks/consul-aws@0.1.2.rb
@@ -1,0 +1,14 @@
+cask 'consul-aws@0.1.2' do
+  version '0.1.2'
+  sha256 'f23c1452f677121dd87b78aa6034afa2d1c2d156639192c239a0048e5354b9c8'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/consul-aws/0.1.2/consul-aws_0.1.2_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/consul-aws/releases.atom'
+  name 'consul-aws'
+  homepage 'https://github.com/hashicorp/consul-aws'
+
+  auto_updates false
+
+  binary 'consul-aws'
+end

--- a/Casks/nomad@0.11.0-rc1.rb
+++ b/Casks/nomad@0.11.0-rc1.rb
@@ -1,0 +1,15 @@
+cask 'nomad@0.11.0-rc1' do
+  version '0.11.0-rc1'
+  sha256 '97ed5fd8678b1cfd0a3d49dd41fe6c44639ff12e1725a71e5f435e58333b5545'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/nomad/0.11.0-rc1/nomad_0.11.0-rc1_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/nomad/releases.atom'
+  name 'Nomad'
+  homepage 'https://www.nomadproject.io/'
+
+  auto_updates false
+  conflicts_with formula: 'nomad'
+
+  binary 'nomad'
+end

--- a/Casks/vault@1.4.0.rb
+++ b/Casks/vault@1.4.0.rb
@@ -1,0 +1,15 @@
+cask 'vault@1.4.0' do
+  version '1.4.0'
+  sha256 '6b25a36b784ba9a57d891b9bdacc65ad2a9d393684a23de8b3967fe58d284af1'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/vault/1.4.0/vault_1.4.0_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/vault/releases.atom'
+  name 'Vault'
+  homepage 'https://www.vaultproject.io/'
+
+  auto_updates false
+  conflicts_with formula: 'vault'
+
+  binary 'vault'
+end

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This Tap provides an exhaustive range of versions for the following applications
   - Vagrant `>= 1.8.0` and `<= 2.2.7`
   - Vault `>= 0.7.0` and `<= 1.4.0-rc1`
 - misc. Casks
-  - `consul-aws` `>= 0.1.0` and `<= 0.1.1`
+  - `consul-aws` `>= 0.1.0` and `<= 0.1.2`
   - `consul-template` `>= 0.1.0` and `<= 0.9.2`
   - `envconsul` `>= 0.1.0` and `<= 0.9.2`
   - `sentinel` `>= 0.10.0` and `<= 0.15.1`

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ This Tap provides an exhaustive range of versions for the following applications
 - main Casks
   - Consul `>= 1.0.0` and `<= 1.7.2`
   - Packer `>= 1.0.0` and `<= 1.5.5`
-  - Nomad `>= 0.8.0-rc1` and `<= 0.11.0-beta2`
+  - Nomad `>= 0.8.0-rc1` and `<= 0.11.0-rc1`
   - Vagrant `>= 1.8.0` and `<= 2.2.7`
-  - Vault `>= 0.7.0` and `<= 1.4.0-rc1`
+  - Vault `>= 0.7.0` and `<= 1.4.0`
 - misc. Casks
   - `consul-aws` `>= 0.1.0` and `<= 0.1.2`
   - `consul-template` `>= 0.1.0` and `<= 0.9.2`

--- a/helpers/VERSIONS.sh
+++ b/helpers/VERSIONS.sh
@@ -63,8 +63,8 @@ CONSUL_1XX=("${CONSUL_10X[@]}" "${CONSUL_11X[@]}" "${CONSUL_12X[@]}" "${CONSUL_1
 #     CONSUL-AWS                                                                                                       #
 ########################################################################################################################
 
-# released between 2018-11 and 2018-12
-CONSUL_AWS_01X=("0.1.0" "0.1.1")
+# released between 2018-11 and 2020-04
+CONSUL_AWS_01X=("0.1.0" "0.1.1" "0.1.2")
 
 CONSUL_AWS_0XX=("${CONSUL_AWS_01X[@]}")
 

--- a/helpers/VERSIONS.sh
+++ b/helpers/VERSIONS.sh
@@ -159,13 +159,14 @@ NOMAD_08X=("0.8.0-rc1" "0.8.0" "0.8.1" "0.8.2" "0.8.3" "0.8.4-rc1" "0.8.4" "0.8.
 # released between 2019-04 and 2019-12
 NOMAD_09X=("0.9.0-beta1" "0.9.0-beta2" "0.9.0-beta3" "0.9.0-rc1" "0.9.0-rc2" "0.9.0" "0.9.1-rc1" "0.9.1" "0.9.2-rc1" "0.9.2" "0.9.3" "0.9.4-rc1" "0.9.4" "0.9.5" "0.9.6" "0.9.7")
 
-# released between 2019-10 and 2020-02
+# released between 2019-10 and 2020-03
 # version `0.10.0-connect1` was not released for macOS and is therefore omitted
 NOMAD_010X_PREFIXED=("0.10.0-beta1" "0.10.0-rc1" "0.10.0" "0.10.1" "0.10.2-rc1" "0.10.2")
 NOMAD_010X_NONPREFIXED=("0.10.3" "0.10.4-rc1" "0.10.4" "0.10.5")
 NOMAD_010X=("${NOMAD_010X_PREFIXED[@]}" "${NOMAD_010X_NONPREFIXED[@]}")
 
-NOMAD_011X=("0.11.0-beta1" "0.11.0-beta2")
+# released between 2019-10 and 2020-04
+NOMAD_011X=("0.11.0-beta1" "0.11.0-beta2" "0.11.0-rc1")
 
 NOMAD_0XX=("${NOMAD_08X[@]}" "${NOMAD_09X[@]}" "${NOMAD_010X[@]}" "${NOMAD_011X[@]}")
 

--- a/helpers/VERSIONS.sh
+++ b/helpers/VERSIONS.sh
@@ -333,9 +333,9 @@ VAULT_12X=("${VAULT_12X_NONPREFIXED[@]}" "${VAULT_12X_PREFIXED[@]}")
 # versions `1.3.0-beta1+ent.hsm`, `1.3.0+ent.hsm`, `1.3.1+ent.hsm`, `1.3.2+ent.hsm`, `1.3.3+ent.hsm`, and `1.3.4+ent.hsm` were not released for macOS and are therefore omitted
 VAULT_13X=("1.3.0" "1.3.0-beta1" "1.3.0-beta1+ent" "1.3.0+ent" "1.3.1" "1.3.1+ent" "1.3.2" "1.3.2+ent" "1.3.3" "1.3.3+ent" "1.3.4" "1.3.4+ent")
 
-# released in 2020-02
+# released between 2020-02 and 2020-04
 # versions `1.4.0-beta1+ent.hsm` and `1.4.0-rc1+ent.hsm` were not released for macOS and are therefore omitted
-VAULT_14X=("1.4.0-beta1" "1.4.0-beta1+ent" "1.4.0-rc1" "1.4.0-rc1+ent")
+VAULT_14X=("1.4.0-beta1" "1.4.0-beta1+ent" "1.4.0-rc1" "1.4.0-rc1+ent" "1.4.0")
 
 VAULT_0XX=("${VAULT_07X[@]}" "${VAULT_08X[@]}" "${VAULT_09X[@]}" "${VAULT_010X[@]}" "${VAULT_011X[@]}")
 VAULT_1XX=("${VAULT_10X[@]}" "${VAULT_11X[@]}" "${VAULT_12X[@]}" "${VAULT_13X[@]}" "${VAULT_14X[@]}")


### PR DESCRIPTION
Updates following newly released versions

# Added Cask(s)

- `consul-aws@0.1.2`
- `nomad@@0.11.0-rc1`
- `vault@1.4.0`

Any other relevant environment information:

```sh

```

# TODO

- [X] Checked open [Pull Requests](https://github.com/operatehappy/homebrew-hashicorp/pulls) for a similar Cask update
- [X] Built the Cask locally and verified its installability
- [X] Tested installability using `brew cask install product@x.y.z.rb`
- [X] Tested uninstallability using `brew cask uninstall product@x.y.z.rb`
- [X] Audited the Cask using `brew cask audit --download product@x.y.z` with no errors
- [X] Style-checked the Cask using `brew cask style --fix product@x.y.z` and reported no offenses
