### PR TITLE
Consul updates

### DIFF
--- a/Casks/consul@1.8.0+ent-rc1.rb
+++ b/Casks/consul@1.8.0+ent-rc1.rb
@@ -1,0 +1,15 @@
+cask 'consul@1.8.0+ent-rc1' do
+  version '1.8.0+ent-rc1'
+  sha256 '3a0c2aeddcdbad8715425866a3308113a5879e57f4d1a5922cc1977b22cb6f1d'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/consul/1.8.0+ent-rc1/consul_1.8.0+ent-rc1_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/consul/releases.atom'
+  name 'Consul'
+  homepage 'https://www.consul.io/'
+
+  auto_updates false
+  conflicts_with formula: 'consul'
+
+  binary 'consul'
+end

--- a/Casks/consul@1.8.0+ent.rb
+++ b/Casks/consul@1.8.0+ent.rb
@@ -1,0 +1,15 @@
+cask 'consul@1.8.0+ent' do
+  version '1.8.0+ent'
+  sha256 '8cf43db8513bd7f6e803f3148806f740daef936bcec6a17b4b2948aae4f09106'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/consul/1.8.0+ent/consul_1.8.0+ent_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/consul/releases.atom'
+  name 'Consul'
+  homepage 'https://www.consul.io/'
+
+  auto_updates false
+  conflicts_with formula: 'consul'
+
+  binary 'consul'
+end

--- a/Casks/consul@1.8.0-rc1.rb
+++ b/Casks/consul@1.8.0-rc1.rb
@@ -1,0 +1,15 @@
+cask 'consul@1.8.0-rc1' do
+  version '1.8.0-rc1'
+  sha256 '54e89e88bb74d6e203685677d9391ab45ec0deab5d99636b34aaef06607a3eb2'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/consul/1.8.0-rc1/consul_1.8.0-rc1_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/consul/releases.atom'
+  name 'Consul'
+  homepage 'https://www.consul.io/'
+
+  auto_updates false
+  conflicts_with formula: 'consul'
+
+  binary 'consul'
+end

--- a/Casks/consul@1.8.0.rb
+++ b/Casks/consul@1.8.0.rb
@@ -1,0 +1,15 @@
+cask 'consul@1.8.0' do
+  version '1.8.0'
+  sha256 'e75e51115e864ab622cbc1873c169be642bcaf35c3b4af257243cbabb9b52753'
+
+  # releases.hashicorp.com was verified as official when first introduced to the cask
+  url 'https://releases.hashicorp.com/consul/1.8.0/consul_1.8.0_darwin_amd64.zip'
+  appcast 'https://github.com/hashicorp/consul/releases.atom'
+  name 'Consul'
+  homepage 'https://www.consul.io/'
+
+  auto_updates false
+  conflicts_with formula: 'consul'
+
+  binary 'consul'
+end

--- a/VERSIONS.sh
+++ b/VERSIONS.sh
@@ -58,7 +58,7 @@ CONSUL_16X=("1.6.0-beta1" "1.6.0-beta2" "1.6.0-beta3" "1.6.0-rc1" "1.6.0" "1.6.0
 CONSUL_17X=("1.7.0-beta1" "1.7.0-beta2" "1.7.0-beta3" "1.7.0-beta4" "1.7.0" "1.7.0+ent-beta2" "1.7.0+ent-beta1" "1.7.0+ent-beta3" "1.7.0+ent" "1.7.0+ent-beta4" "1.7.1" "1.7.1+ent" "1.7.2" "1.7.2+ent" "1.7.3" "1.7.3+ent" "1.7.4" "1.7.4+ent")
 
 # released between 2020-05 and
-CONSUL_18X=("1.8.0-beta1" "1.8.0+ent-beta1" "1.8.0-beta2" "1.8.0+ent-beta2")
+CONSUL_18X=("1.8.0-beta1" "1.8.0+ent-beta1" "1.8.0-beta2" "1.8.0+ent-beta2" "1.8.0-rc1" "1.8.0+ent-rc1" "1.8.0" "1.8.0+ent")
 
 CONSUL_1XX=("${CONSUL_10X[@]}" "${CONSUL_11X[@]}" "${CONSUL_12X[@]}" "${CONSUL_13X[@]}" "${CONSUL_14X[@]}" "${CONSUL_15X[@]}" "${CONSUL_16X[@]}" "${CONSUL_17X[@]}" "${CONSUL_18X[@]}")
 


### PR DESCRIPTION
Adds 1.8.0 and RC1 for Consul!

# Added Cask(s)

- `consul@1.8.0-rc1`
- `consul@1.8.0+ent-rc1`
- `consul@1.8.0`
- `consul@1.8.0+ent`

# TODO

- [x] Checked open [Pull Requests](https://github.com/operatehappy/homebrew-hashicorp/pulls) for a similar Cask update
- [x] Built the Cask locally and verified its installability
- [x] Tested installability using `brew cask install product@x.y.z.rb`
- [x] Tested uninstallability using `brew cask uninstall product@x.y.z.rb`
- [x] Audited the Cask using `brew cask audit --download product@x.y.z` with no errors
- [x] Style-checked the Cask using `brew cask style --fix product@x.y.z` and reported no offenses
